### PR TITLE
Removed Apstra refrence and formating of README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # terraform-provider-mist
 
-
 ## Requirements
-
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
 - [Go](https://golang.org/doc/install) >= 1.21
 - [Mist API Go package](https://pkg.go.dev/github.com/tmunzer/mistapi-go) >= 0.2.5
@@ -14,12 +12,11 @@ Instructions for popular operating systems can be found [here](https://developer
 
 ### Create a Terraform configuration
 The terraform configuration must:
-* be named with a .tf file extension.
-* reference this provider by its global address (`registry.terraform.io/Juniper/mist`) or just `Juniper/mist`.
-* include a provider configuration block which tells the provider which Mist Cloud must be used and which credentials to use.
-  
+* Be named with a .tf file extension.
+* Reference this provider by its global address (`registry.terraform.io/Juniper/mist`) or just `Juniper/mist`.
+* Include a provider configuration block which tells the provider which Mist Cloud must be used and which credentials to use.
 
-```terraform
+```hcl
 terraform {
   required_providers {
     mist = {
@@ -29,24 +26,27 @@ terraform {
 }
 
 provider "mist" {
-  host     = "api.mist.com"
+  host = "api.mist.com"
   apitoken = "xxxxxxxxxxxxxxxxxxxxxxxxx"
 }
 ```
 
 ### Terraform Init
-Run the following at a command prompt while in the same directory as the configuration file to fetch the Apstra provider plugin.
+Run the following at a command prompt while in the same directory as the configuration file to fetch the Mist provider plugin:
+
 ```console
 terraform init
 ```
 
 ### Credentials
 Mist credentials can be supplied in the provider configuration block or through environment variables (recommended):
+
 * API Token:
 ```console
 export MIST_APITOKEN=<apitoken>
 ```
-* Username and Password
+
+* Username and Password:
 ```console
 export MIST_USERNAME=<username>
 export MIST_PASSWORD=<password>
@@ -55,7 +55,5 @@ export MIST_PASSWORD=<password>
 ### Start configuring resources
 Full documentation for provider, resources and data sources can be found [here](https://registry.terraform.io/providers/Juniper/mist/latest/docs).
 
+## Contributing
 See the open issues for a full list of proposed features (and known issues).
-
-
-


### PR DESCRIPTION
Hey @tmunzer old buddy old pal!,

I Improve README formatting and clarity for terraform-provider-mist

- Removed the **Apstra** Refrence on line  38. 
 ![Homelander no no no](https://i.giphy.com/nzsWN8iSDwSlhCDokc.gif)
- Fixed some indentation and spacing issues
- Update code block language specifiers for better syntax highlighting (terraform for hcl)
- Ensure consistent capitalization of "Terraform"
- Add missing punctuation, newline etc.
- Small readability improvements


