### PR TITLE
Add API debugging support with enhanced logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ website/vendor
 # Keep windows files with windows line endings
 *.winfile eol=crlf
 .env
+.vscode/launch.json
+.vscode/settings.json

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,14 @@ go 1.22.7
 toolchain go1.23.3
 
 require (
+	github.com/apimatic/go-core-runtime v0.0.27
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.15.0
 	github.com/hashicorp/terraform-plugin-go v0.25.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/tmunzer/mistapi-go v0.4.22
 	golang.org/x/net v0.32.0
 )
@@ -23,12 +25,12 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
-	github.com/apimatic/go-core-runtime v0.0.27 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.2.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.7.1 // indirect
 	github.com/cloudflare/circl v1.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/cli v1.1.6 // indirect
@@ -55,11 +57,11 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yuin/goldmark v1.7.8 // indirect

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -7,6 +7,7 @@ const (
 	envPassword          = "MIST_PASSWORD"
 	envApiTimeout        = "MIST_API_TIMEOUT"
 	envProxy             = "MIST_PROXY"
+	envDebug             = "MIST_API_DEBUG"
 	docCategorySeparator = " --- "
 	docCategorySite      = "Site" + docCategorySeparator
 	docCategoryOrg       = "Org" + docCategorySeparator

--- a/internal/provider/logger.go
+++ b/internal/provider/logger.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/apimatic/go-core-runtime/logger"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type TFLogger struct {
+	ctx context.Context
+}
+
+func NewTFlogger(ctx context.Context) *TFLogger {
+	return &TFLogger{ctx: ctx}
+}
+
+func (l *TFLogger) Trace(msg string, args ...interface{}) {
+	tflog.Trace(l.ctx, msg)
+}
+
+func (l *TFLogger) Debug(msg string, args ...interface{}) {
+	tflog.Debug(l.ctx, msg)
+}
+
+func (l *TFLogger) Info(msg string, args ...interface{}) {
+	tflog.Info(l.ctx, msg)
+}
+
+func (l *TFLogger) Warn(msg string, args ...interface{}) {
+	tflog.Warn(l.ctx, msg)
+}
+
+func (l *TFLogger) Error(msg string, args ...interface{}) {
+	tflog.Error(l.ctx, msg)
+}
+
+func (l *TFLogger) Log(level logger.Level, message string, metadata map[string]interface{}) {
+
+	formattedMessage := formatLog(message, metadata)
+
+	switch level {
+	case logger.Level_INFO:
+		tflog.Info(l.ctx, formattedMessage)
+	case logger.Level_TRACE:
+		tflog.Trace(l.ctx, formattedMessage)
+	case logger.Level_DEBUG:
+		tflog.Debug(l.ctx, formattedMessage)
+	case logger.Level_WARN:
+		tflog.Warn(l.ctx, formattedMessage)
+	case logger.Level_ERROR:
+		tflog.Error(l.ctx, formattedMessage)
+	default:
+		tflog.Debug(l.ctx, formattedMessage)
+	}
+}
+
+func formatLog(message string, metadata map[string]interface{}) string {
+	var logBuilder strings.Builder
+
+	logBuilder.WriteString("SDK API Log: ")
+	logBuilder.WriteString(message)
+
+	if len(metadata) > 0 {
+		logBuilder.WriteString("\n")
+		for key, value := range metadata {
+
+			strValue := fmt.Sprintf("%v", value)
+			if isJSON(strValue) {
+				strValue = formatJSON(strValue)
+			}
+			logBuilder.WriteString(fmt.Sprintf("  %s: %s\n", key, strValue))
+		}
+	}
+
+	return logBuilder.String()
+}
+
+func isJSON(s string) bool {
+	var js json.RawMessage
+	return json.Unmarshal([]byte(s), &js) == nil
+}
+
+func formatJSON(jsonStr string) string {
+	var formattedJSON bytes.Buffer
+	if err := json.Indent(&formattedJSON, []byte(jsonStr), "", "  "); err != nil {
+		return jsonStr
+	}
+	return formattedJSON.String()
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,290 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/tmunzer/mistapi-go/mistapi"
+)
+
+func TestDebugEnvVariable_True(t *testing.T) {
+	t.Setenv("MIST_API_DEBUG", "true")
+
+	var p mistProviderModel
+	var diags diag.Diagnostics
+	p.fromEnv(context.Background(), &diags)
+	if !p.ApiDebug.ValueBool() {
+		t.Errorf("ApiDebug not set correctly from environment variable")
+	}
+}
+func TestDebugEnvVariable_False(t *testing.T) {
+	t.Setenv("MIST_API_DEBUG", "false")
+
+	var p mistProviderModel
+	var diags diag.Diagnostics
+	p.fromEnv(context.Background(), &diags)
+	if p.ApiDebug.ValueBool() {
+		t.Errorf("ApiDebug not set correctly from environment variable")
+	}
+}
+func TestDebugEnvVariable_Null(t *testing.T) {
+	var p mistProviderModel
+	var diags diag.Diagnostics
+	p.fromEnv(context.Background(), &diags)
+	if p.ApiDebug.ValueBool() {
+		t.Errorf("ApiDebug not set correctly from environment variable")
+	}
+}
+
+func TestFromEnv_ApiDebug(t *testing.T) {
+	tests := []struct {
+		name          string
+		envValue      string
+		expectedValue bool
+		expectError   bool
+		envIsUnset    bool
+	}{
+		{
+			name:          "ApiDebug true from env variable",
+			envValue:      "true",
+			expectedValue: true,
+		},
+		{
+			name:          "ApiDebug false from env variable",
+			envValue:      "false",
+			expectedValue: false,
+		},
+		{
+			name:        "Invalid ApiDebug value",
+			envValue:    "invalid",
+			expectError: true,
+		},
+		{
+			name:       "ApiDebug unset",
+			envIsUnset: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.envIsUnset {
+				t.Setenv("MIST_API_DEBUG", tt.envValue)
+			} else {
+				os.Unsetenv("MIST_API_DEBUG")
+			}
+
+			var p mistProviderModel = mistProviderModel{
+				ApiDebug: types.BoolNull(),
+			}
+
+			var diags diag.Diagnostics
+
+			p.fromEnv(context.Background(), &diags)
+
+			if tt.expectError {
+				if !diags.HasError() {
+					t.Errorf("expected an error but got none")
+				}
+				return
+			} else if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			if !p.ApiDebug.IsNull() {
+				if p.ApiDebug.ValueBool() != tt.expectedValue {
+					t.Errorf("expected ApiDebug to be %v, got %v", tt.expectedValue, p.ApiDebug.ValueBool())
+				}
+			} else if !tt.envIsUnset {
+				t.Errorf("expected ApiDebug to be set, but it was null")
+			}
+		})
+	}
+}
+
+func TestIntegration_Configure_Invalid_Configuration(t *testing.T) {
+
+	testProvider := New()()
+	schemaResponse := new(provider.SchemaResponse)
+
+	testProvider.Schema(context.Background(), provider.SchemaRequest{}, schemaResponse)
+
+	testConfig := tfsdk.Config{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"host":        tftypes.String,
+				"apitoken":    tftypes.String,
+				"username":    tftypes.String,
+				"password":    tftypes.String,
+				"api_timeout": tftypes.Number,
+				"api_debug":   tftypes.Bool,
+				"proxy":       tftypes.String,
+			},
+		}, map[string]tftypes.Value{
+			"host":        tftypes.NewValue(tftypes.String, "api.mist.com"),
+			"apitoken":    tftypes.NewValue(tftypes.String, "fake-token"),
+			"username":    tftypes.NewValue(tftypes.String, nil),
+			"password":    tftypes.NewValue(tftypes.String, nil),
+			"api_timeout": tftypes.NewValue(tftypes.Number, nil),
+			"api_debug":   tftypes.NewValue(tftypes.Bool, nil),
+			"proxy":       tftypes.NewValue(tftypes.String, nil),
+		}),
+		Schema: schemaResponse.Schema,
+	}
+
+	req := provider.ConfigureRequest{
+		Config: testConfig,
+	}
+	resp := provider.ConfigureResponse{}
+
+	testProvider.Configure(context.Background(), req, &resp)
+
+	if resp.Diagnostics.HasError() {
+		assert.Equal(t, diag.Diagnostics{diag.NewErrorDiagnostic("Authentication Error", "ResponseHttp401Error occured: Unauthorized")}, resp.Diagnostics)
+	}
+}
+func TestIntegration_Configure_API_Token(t *testing.T) {
+	ValidateEnvVars(t, []string{"TEST_MIST_API_TOKEN"})
+
+	testProvider := New()()
+	schemaResponse := new(provider.SchemaResponse)
+
+	testProvider.Schema(context.Background(), provider.SchemaRequest{}, schemaResponse)
+
+	testConfig := tfsdk.Config{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"host":        tftypes.String,
+				"apitoken":    tftypes.String,
+				"username":    tftypes.String,
+				"password":    tftypes.String,
+				"api_timeout": tftypes.Number,
+				"api_debug":   tftypes.Bool,
+				"proxy":       tftypes.String,
+			},
+		}, map[string]tftypes.Value{
+			"host":        tftypes.NewValue(tftypes.String, "api.mist.com"),
+			"apitoken":    tftypes.NewValue(tftypes.String, os.Getenv("TEST_MIST_API_TOKEN")),
+			"username":    tftypes.NewValue(tftypes.String, nil),
+			"password":    tftypes.NewValue(tftypes.String, nil),
+			"api_timeout": tftypes.NewValue(tftypes.Number, nil),
+			"api_debug":   tftypes.NewValue(tftypes.Bool, nil),
+			"proxy":       tftypes.NewValue(tftypes.String, nil),
+		}),
+		Schema: schemaResponse.Schema,
+	}
+
+	req := provider.ConfigureRequest{
+		Config: testConfig,
+	}
+	resp := provider.ConfigureResponse{}
+
+	testProvider.Configure(context.Background(), req, &resp)
+	assert.NotEmpty(t, resp.ResourceData.(mistapi.ClientInterface).Configuration().ApiTokenCredentials())
+	assert.Empty(t, resp.ResourceData.(mistapi.ClientInterface).Configuration().BasicAuthCredentials())
+	assert.Empty(t, resp.ResourceData.(mistapi.ClientInterface).Configuration().CsrfTokenCredentials())
+}
+
+func TestIntegration_Configure_Basic_Auth(t *testing.T) {
+	ValidateEnvVars(t, []string{"TEST_MIST_USERNAME", "TEST_MIST_PASSWORD"})
+
+	testProvider := New()()
+	schemaResponse := new(provider.SchemaResponse)
+
+	testProvider.Schema(context.Background(), provider.SchemaRequest{}, schemaResponse)
+
+	testConfig := tfsdk.Config{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"host":        tftypes.String,
+				"apitoken":    tftypes.String,
+				"username":    tftypes.String,
+				"password":    tftypes.String,
+				"api_timeout": tftypes.Number,
+				"api_debug":   tftypes.Bool,
+				"proxy":       tftypes.String,
+			},
+		}, map[string]tftypes.Value{
+			"host":        tftypes.NewValue(tftypes.String, "api.mist.com"),
+			"apitoken":    tftypes.NewValue(tftypes.String, nil),
+			"username":    tftypes.NewValue(tftypes.String, os.Getenv("TEST_MIST_USERNAME")),
+			"password":    tftypes.NewValue(tftypes.String, os.Getenv("TEST_MIST_PASSWORD")),
+			"api_timeout": tftypes.NewValue(tftypes.Number, nil),
+			"api_debug":   tftypes.NewValue(tftypes.Bool, nil),
+			"proxy":       tftypes.NewValue(tftypes.String, nil),
+		}),
+		Schema: schemaResponse.Schema,
+	}
+
+	req := provider.ConfigureRequest{
+		Config: testConfig,
+	}
+	resp := provider.ConfigureResponse{}
+
+	testProvider.Configure(context.Background(), req, &resp)
+	assert.Empty(t, resp.ResourceData.(mistapi.ClientInterface).Configuration().ApiTokenCredentials())
+	assert.NotEmpty(t, resp.ResourceData.(mistapi.ClientInterface).Configuration().BasicAuthCredentials())
+	assert.NotEmpty(t, resp.ResourceData.(mistapi.ClientInterface).Configuration().CsrfTokenCredentials())
+}
+
+func TestIntegration_Configure_API_DEBUG(t *testing.T) {
+	ValidateEnvVars(t, []string{"TEST_MIST_API_TOKEN"})
+
+	testProvider := New()()
+	schemaResponse := new(provider.SchemaResponse)
+
+	testProvider.Schema(context.Background(), provider.SchemaRequest{}, schemaResponse)
+
+	testConfig := tfsdk.Config{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"host":        tftypes.String,
+				"apitoken":    tftypes.String,
+				"username":    tftypes.String,
+				"password":    tftypes.String,
+				"api_timeout": tftypes.Number,
+				"api_debug":   tftypes.Bool,
+				"proxy":       tftypes.String,
+			},
+		}, map[string]tftypes.Value{
+			"host":        tftypes.NewValue(tftypes.String, "api.mist.com"),
+			"apitoken":    tftypes.NewValue(tftypes.String, os.Getenv("TEST_MIST_API_TOKEN")),
+			"username":    tftypes.NewValue(tftypes.String, nil),
+			"password":    tftypes.NewValue(tftypes.String, nil),
+			"api_timeout": tftypes.NewValue(tftypes.Number, nil),
+			"api_debug":   tftypes.NewValue(tftypes.Bool, true),
+			"proxy":       tftypes.NewValue(tftypes.String, nil),
+		}),
+		Schema: schemaResponse.Schema,
+	}
+
+	req := provider.ConfigureRequest{
+		Config: testConfig,
+	}
+	resp := provider.ConfigureResponse{}
+
+	testProvider.Configure(context.Background(), req, &resp)
+	assert.False(t, resp.Diagnostics.HasError(), "Unexpected error in diagnostics: %v", resp.Diagnostics)
+}
+
+func ValidateEnvVars(t *testing.T, requiredVars []string) {
+	t.Helper()
+
+	missingVars := []string{}
+	for _, envVar := range requiredVars {
+		if _, exists := os.LookupEnv(envVar); !exists {
+			missingVars = append(missingVars, envVar)
+		}
+	}
+
+	if len(missingVars) > 0 {
+		t.Errorf("Test missing required environment variables: %v", missingVars)
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
This commit adds a logger to the provider to help with debugging API calls. The logger is disabled by default and can be enabled by setting the environment variable `MIST_API_DEBUG=true`. Test cases have been added to verify that the provider is functioning as expected and the refactoring that has been made does not break any existing functionality