### PR TITLE
Add acceptance test for site resource routertemplate_id field

### DIFF
--- a/internal/provider/fixtures/site_resource/site_resource_config.tf
+++ b/internal/provider/fixtures/site_resource/site_resource_config.tf
@@ -14,6 +14,7 @@ latlng = {
 networktemplate_id     = "00000000-0000-0000-4000-5c5b35000040"
 notes                  = "This is a comprehensive test site with all major configuration options"
 rftemplate_id          = "00000000-0000-0000-5000-5c5b35000050"
+routertemplate_id      = "00000000-0000-0000-5500-5c5b35000055"
 secpolicy_id           = "00000000-0000-0000-6000-5c5b35000060"
 sitegroup_ids          = ["00000000-0000-0000-7000-5c5b35000070", "00000000-0000-0000-7000-5c5b35000071"]
 sitetemplate_id        = "00000000-0000-0000-8000-5c5b35000080"

--- a/internal/provider/site_resource_test.go
+++ b/internal/provider/site_resource_test.go
@@ -157,12 +157,17 @@ func (s *SiteModel) testChecks(t testing.TB, rType, tName string, tracker *valid
 		checks.append(t, "TestCheckResourceAttr", "rftemplate_id", *s.RftemplateId)
 	}
 
-	// 13. SecpolicyId (optional)
+	// 13. RoutertemplateId (optional)
+	if s.RoutertemplateId != nil {
+		checks.append(t, "TestCheckResourceAttr", "routertemplate_id", *s.RoutertemplateId)
+	}
+
+	// 14. SecpolicyId (optional)
 	if s.SecpolicyId != nil {
 		checks.append(t, "TestCheckResourceAttr", "secpolicy_id", *s.SecpolicyId)
 	}
 
-	// 14. SitegroupIds (optional array)
+	// 15. SitegroupIds (optional array)
 	if len(s.SitegroupIds) > 0 {
 		checks.append(t, "TestCheckResourceAttr", "sitegroup_ids.#", fmt.Sprintf("%d", len(s.SitegroupIds)))
 		for i, id := range s.SitegroupIds {
@@ -170,17 +175,17 @@ func (s *SiteModel) testChecks(t testing.TB, rType, tName string, tracker *valid
 		}
 	}
 
-	// 15. SitetemplateId (optional)
+	// 16. SitetemplateId (optional)
 	if s.SitetemplateId != nil {
 		checks.append(t, "TestCheckResourceAttr", "sitetemplate_id", *s.SitetemplateId)
 	}
 
-	// 16. Timezone (optional)
+	// 17. Timezone (optional)
 	if s.Timezone != nil {
 		checks.append(t, "TestCheckResourceAttr", "timezone", *s.Timezone)
 	}
 
-	// 17. Tzoffset (computed-only)
+	// 18. Tzoffset (computed-only)
 	checks.append(t, "TestCheckResourceAttrSet", "tzoffset")
 
 	return checks


### PR DESCRIPTION
Added acceptance test for site resource `routertemplate_id` field after recent update to resource.
Internal ref: MIST-182532